### PR TITLE
fix: typename is required to satisfy two-phase name lookup

### DIFF
--- a/winwrap/WindowHandle.hpp
+++ b/winwrap/WindowHandle.hpp
@@ -58,7 +58,7 @@ namespace WinWrap {
         };
 
         template<GetWindowLongMode nIndex>
-        using GetWindowLongRet_t = GetWindowLongRet<nIndex>::type;
+        using GetWindowLongRet_t = typename GetWindowLongRet<nIndex>::type;
 
         template<GetWindowLongMode nIndex, class R = GetWindowLongRet_t<nIndex>> R getWindowLong() const;
 


### PR DESCRIPTION
`GetWindowLongRet<nIndex>::type` is dependent name so that `typename` is required.